### PR TITLE
Feature/aws configuration overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This plugin allows any requests to AWS to be redirected to a running Localstack instance.
 
+WARNING: This plugin is very much WIP
+
 Pre-requisites:
 * Localstack
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ ln -s /absolute/path/to/plugin .serverless_plugins/serverless-plugin-localstack
 
 ## Configuring
 
-There are two ways to configure the plugin, via a JSON file or via serverless.yml.
+There are two ways to configure the plugin, via a JSON file or via serverless.yml. There are two supported methods for
+configuring the endpoints, globally via the "host" property, or individually. These properties may be mixed, allowing for
+global override support while also override specific endpoints.
 
-#### Configuring endpoints via serverless.yml
+A "host" or individual endpoints must be configured or this plugin will be deactivated.
+
+#### Configuring endpoints via serverless.yml 
 
 ```
 service: myService
@@ -46,6 +50,7 @@ plugins:
 
   custom:
     localstack:
+      host: http://localhost
       endpoints:
         S3: http://localhost:4572
         DynamoDB: http://localhost:4570
@@ -66,7 +71,86 @@ service: myService
 plugins:
   - serverless-plugin-localstack
 
-  custom:
-    localstack:
-      endpointFile: path/to/file.json
+custom:
+  localstack:
+    endpointFile: path/to/file.json
+```
+
+## Localstack
+
+For full documentation, see https://bitbucket.org/atlassian/localstack
+
+#### Installing via PIP
+
+The easiest way to get started with Localstack is to install it via Python's pip.
+
+```
+pip install localstack
+```
+
+#### Installing via Source
+
+Clone the repository
+```
+git clone git@bitbucket.org:atlassian/localstack.git
+```
+
+### Running Localstack
+
+There are multiple ways to run Localstack.
+
+#### Starting Localstack via Docker
+  
+If Localstack is installed via pip
+
+```
+localstack start --docker
+```
+
+If Localstack is installed via source
+
+```
+make docker-run
+```
+
+#### Starting Localstack without Docker
+
+If Localstack is installed via pip
+
+```
+localstack start
+```
+
+If Localstack is installed via source
+
+```
+make infra
+```
+
+## Contributing
+
+Setting up a development environment is easy using Serverless' plugin framework.
+
+##### Clone the Repo
+
+```
+git clone https://github.com/temyers/serverless-localstack
+```
+
+##### Setup your project
+
+```
+cd myproject
+mkdir .serverless_plugins
+ln -s /absolute/path/to/serverless-localstack .serverless_plugins/serverless-localstack
+```
+
+### Optional Debug Flag
+
+An optional debug flag is supported via serverless.yml that will enable additional debug logs.
+
+```
+custom:
+  localstack:
+    debug: true
 ```

--- a/README.md
+++ b/README.md
@@ -1,36 +1,70 @@
-#serverless-plugin-localstack
+# serverless-localstack
 [Serverless](https://serverless.com/) Plugin to support running against [Atlassian Labs Localstack](https://github.com/atlassian/localstack).
 
-WARNING: This plugin is very much WIP
+This plugin allows any requests to AWS to be redirected to a running Localstack instance.
 
 Pre-requisites:
-* Docker
-* Docker compose
-* Serverless: `npm install -g serverless`
+* Localstack
 
+## Installation
 
-Getting Started:
+The easiest way to get started is to install via npm.
 
-* Clone the repository
-`git clone https://github.com/temyers/serverless-localstack`
+    npm install -g serverless
+    npm install -g serverless-localstack
 
-* Start localstack
-`docker-compose up localstack`
+## Installation (without npm)
 
-* Start your Serverless container:
-`docker-compose run serverless-node bash`
+If you'd like to install serverless-localstack via source:
 
-* Install Serverless
-`npm install -g serverless`
+#### Clone the repository
+      git clone https://github.com/temyers/serverless-localstack
 
-* cd to example directory
-`cd /app/example/service`
+#### Install the plugin
 
-* "install" the plugin
+In order for the plugin to be recognized it must first be enabled via the .serverless_plugins directory.
+
 ```
+cd project-path/
 mkdir .serverless_plugins
-ln -s /app/src .serverless_plugins/serverless-plugin-localstack
+ln -s /absolute/path/to/plugin .serverless_plugins/serverless-plugin-localstack
 ```
 
-* Deploy the service
-`serverless deploy`
+## Configuring
+
+There are two ways to configure the plugin, via a JSON file or via serverless.yml.
+
+#### Configuring endpoints via serverless.yml
+
+```
+service: myService
+
+plugins:
+  - serverless-plugin-localstack
+
+  custom:
+    localstack:
+      endpoints:
+        S3: http://localhost:4572
+        DynamoDB: http://localhost:4570
+        CloudFormation: http://localhost:4581
+        Elasticsearch: http://localhost:4571
+        ES: http://localhost:4578
+        SNS: http://localhost:4575
+        SQS: http://localhost:4576
+        Lambda: http://localhost:4574
+        Kinesis: http://localhost:4568
+```
+
+#### Configuring endpoints via JSON
+
+```
+service: myService
+
+plugins:
+  - serverless-plugin-localstack
+
+  custom:
+    localstack:
+      endpointFile: path/to/file.json
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "serverless-plugin-localstack",
-  "version": "0.0.1",
+  "name": "serverless-localstack",
+  "version": "0.0.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {
@@ -16,6 +16,9 @@
     "url": "git+ssh://git@github.com/temyers/serverless-localstack"
   },
   "author": "TODO",
+  "contributors": [
+    "Justin McCormick <me@justinmccormick.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "TODO"

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -7,264 +7,173 @@ const AWS = require('aws-sdk');
 const BbPromise = require('bluebird');
 const Serverless = require('serverless')
 const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider')
+const path = require('path');
+const localstackEndpointsFile = path.normalize( path.join(__dirname, '../../example/service/localstack_endpoints.json') );
 
-const localstackEndpointsFile='/app/example/service/localstack_endpoints.json'
+const debug = false;
 
 describe("LocalstackPlugin", () => {
 
+  let serverless;
+  let instance;
+
+  beforeEach(() => {
+    serverless = {
+      cli: {
+        log: (msg) => {
+          if (debug) {
+            console.log(msg)
+          }
+        }
+      },
+      service: {
+        custom: {
+          localstack: {
+            debug: debug,
+            endpoints: {
+              'S3': 'http://localhost:4572'
+            }
+          }
+        }
+      },
+      providers: {
+        aws: {
+          request: () => {},
+          setProvider: () => {}
+        }
+      }
+    };
+  });
+
   describe('#constructor()', () => {
 
-    shouldProvideHooks = ()=>{
-      expect(this.instance.hooks).not.to.be.undefined
-    }
-
     describe('Config missing', () => {
+
         beforeEach(() => {
-          this.serverless={
-            service: {
-              cli: {
-                log: (msg) => {console.log(msg)}
-              }
-            },
-            providers: {
-              aws:{
-                request: ()=>{}
-              }
-            }
-          };
+          serverless.service.custom = null;
+          instance = new LocalstackPlugin(serverless, {});
         });
 
-        it('should not set the endpoint', ()=> {
-          this.instance = new LocalstackPlugin(this.serverless, {})
-          expect(this.instance.endpoint).to.be.undefined
-        });
-
-        it('should provide hooks', () =>{
-          this.instance = new LocalstackPlugin(this.serverless, {})
-          expect(shouldProvideHooks()).to.not.throw
+        it('should not set the endpoint', () => {
+          expect(instance.endpoints).to.be.empty;
         });
 
     });
     describe('Config empty', () => {
-        beforeEach(() => {
-          this.serverless={
-            service: {
-              cli: {
-                log: (msg) => {console.log(msg)}
-              },
-              custom: {
-              },
-            },
-            providers: {
-              aws:{
-                options: {},
-                request: ()=>{}
-              }
-            }
-          };
-          this.instance = new LocalstackPlugin(this.serverless, {})
-        });
 
         it('should not set the endpoint', ()=> {
-          expect(this.instance.endpoint).to.be.undefined
+          serverless.service.custom.localstack = {};
+          instance = new LocalstackPlugin(serverless, {})
+
+          expect(instance.endpoints).to.be.empty;
+          expect(instance.hooks).to.be.empty;
         });
 
-        it('should provide hooks', shouldProvideHooks)
-
-        it('should not set the endpoints on the AWS provider when endpoints not defined', ()=> {
-          expect(this.instance.serverless.providers.aws.options.serverless_localstack).to.be.undefined
-        })
-
         it('should fail if the endpoint file does not exist', () => {
-          this.serverless.service.custom.localstack={
-            endpoint: 'missing.json'
+          serverless.service.custom.localstack = {
+            endpointFile: 'missing.json'
           }
-          plugin = () => { new LocalstackPlugin(this.serverless, {}) }
-          expect(plugin).to.throw('Endpoint: "missing.json" could not be found.')
+          let plugin = () => { new LocalstackPlugin(serverless, {}) }
+          expect(plugin).to.throw('Endpoint: "missing.json" is invalid:')
         });
 
         it('should fail if the endpoint file is not json', () => {
-          this.serverless.service.custom.localstack={
-            endpoint: 'README.md'
+          serverless.service.custom.localstack = {
+            endpointFile: 'README.md'
           }
-          plugin = () => { new LocalstackPlugin(this.serverless, {}) }
-          expect(plugin).to.throw(/Endpoint: "README.md" is invalid./)
+          let plugin = () => { new LocalstackPlugin(serverless, {}) }
+          expect(plugin).to.throw(/Endpoint: "README.md" is invalid:/)
 
-        })
-    });
-    describe('Config empty', () => {
-        beforeEach(() => {
-          this.serverless={
-            service: {
-              cli: {
-                log: (msg) => {console.log(msg)}
-              },
-              custom: {
-                localstack: {}
-              },
-            },
-            providers: {
-              aws:{
-                request: ()=>{}
-              }
-            }
-          };
-          this.instance = new LocalstackPlugin(this.serverless, {})
-        });
-
-        it('should not set the endpoint', ()=> {
-          expect(this.instance.endpoint).to.be.undefined
-        });
-
-        it('should provide hooks', shouldProvideHooks)
-
-        it('should not set the endpoints on the AWS provider when provider options not defined', ()=> {
-          expect(this.instance.serverless.providers.aws.options).to.be.undefined
         })
     });
 
     describe('Config provided', () => {
       beforeEach(() => {
-        this.serverless={
-          service: {
-            cli: {
-              log: (msg) => {console.log(msg)}
-            },
-            custom: {
-              localstack: {
-                endpoint: localstackEndpointsFile,
-              },
-            },
-          },
-          providers: {
-            aws:{
-              options: {},
-              request: ()=>{}
-            }
-          }
-        };
-        this.instance = new LocalstackPlugin(this.serverless, {})
+        serverless.service.custom.localstack.endpointFile = localstackEndpointsFile;
+        instance = new LocalstackPlugin(serverless, {})
       });
 
-
-      it('should provide hooks', shouldProvideHooks)
-
-      it('should set the endpoint', () => {
-        expect(this.instance.endpoint).to.equal(localstackEndpointsFile)
+      it('should set the endpoint file', () => {
+        expect(instance.endpointFile).to.equal(localstackEndpointsFile)
       });
 
       it('should copy the endpoints to the AWS provider options', ()=> {
-        endpoints=JSON.parse(fs.readFileSync(localstackEndpointsFile))
+        let endpoints = JSON.parse(fs.readFileSync(localstackEndpointsFile))
 
-        expect(this.instance.serverless.providers.aws.options.serverless_localstack.endpoints).to.deep.equal(endpoints)
+        expect(instance.endpoints).to.deep.equal(endpoints)
       })
 
     });
   });
 
-    it('should bind the provider request method', ()=> {
-      var requestMethod = jasmine.createSpy('requestMethod')
-      this.serverless={
-        service: {
-          cli: {
-            log: (msg) => {console.log(msg)}
-          },
-          custom: {
-            localstack: {
-              endpoint: localstackEndpointsFile,
-            },
-          },
-        },
-        providers: {
-          aws:{
-            options: {},
-            request: requestMethod
-          }
-        }
-      };
-      this.instance = new LocalstackPlugin(this.serverless, {})
-      expect(this.instance.providerRequest).not.to.be.undefined
-      this.instance.providerRequest()
-      expect(requestMethod.calls.count()).to.equal(1)
-    });
+  describe('#request() bound on AWS provider', ()=>{
 
-    describe('#request() bound on AWS provider', ()=>{
-
-      beforeEach(()=> {
-        var that=this;
-        class FakeService {
-          constructor(credentials) {
-            that.credentials = credentials;
-          }
-
-          foo(){
-            return this;
-          }
-
-          send(){
-            return this;
-          }
-        }
-        this.FakeService = FakeService
-        const options={}
-        this.serverless = new Serverless(options);
-        this.serverless.cli = {
-          log: (msg) => {console.log(msg)}
-        }
-        this.serverless.service.custom = {
-          localstack: {
-            endpoint: localstackEndpointsFile,
-          },
+    beforeEach(()=> {
+      var that=this;
+      class FakeService {
+        constructor(credentials) {
+          that.credentials = credentials;
         }
 
-        this.serverlessAwsProvider = new AwsProvider(this.serverless, {})
-        this.serverless.providers.aws=this.serverlessAwsProvider
+        foo() {
+          return this;
+        }
 
-      });
-
-      it('should set the endpoint on the AWS provider when a provider request is invoked and the endpoint has been defined',
-      (done)=> {
-        this.serverlessAwsProvider.sdk = {
-          Lambda: this.FakeService,
-        };
-
-        this.instance = new LocalstackPlugin(this.serverless, {})
-
-        this.serverless.providers.aws.request('Lambda','foo',{});
-
-        expect(this.credentials.endpoint).to.equal('http://localstack:4574')
-        done()
-      });
-
-      it('should not set the endpoint if the required endpoint service is not defined', (done) => {
-        this.serverlessAwsProvider.sdk = {
-          Lambda: this.FakeService,
-          bobbins: this.FakeService,
-        };
-
-        this.instance = new LocalstackPlugin(this.serverless, {})
-
-        this.serverless.providers.aws.request('bobbins','foo',{});
-
-        expect(this.endpoint).to.be.undefined
-        done()
-      });
-
-    });
-
-    afterEach(()=>{
-      this.endpoint=undefined
-    })
-
-    it('should allow the endpoint.json to be referenced from the working dir', () => {
-      this.serverless.service.custom = {
-        localstack: {
-          endpoint: 'example/service/localstack_endpoints.json',
-        },
+        send(){
+          return this;
+        }
       }
-      this.instance = new LocalstackPlugin(this.serverless, {})
-      // TODO approval testing
-      expect(this.instance.endpoint).not.to.be.undefined
+      this.FakeService = FakeService
+      const options = {}
+      serverless = new Serverless(options);
+      serverless.cli = {
+        log: (msg) => {
+          if (debug) {
+            console.log(msg)
+          }
+        }
+      }
+
+      serverless.service.custom = {
+        localstack: {
+          endpointFile: localstackEndpointsFile,
+        }
+      }
+
+      this.serverlessAwsProvider = new AwsProvider(serverless, {})
+      serverless.providers.aws=this.serverlessAwsProvider
+
     });
+
+    it('should set the endpoint on the AWS provider when a provider request is invoked and the endpoint has been defined',
+    (done)=> {
+      this.serverlessAwsProvider.sdk = {
+        Lambda: this.FakeService,
+      };
+
+      instance = new LocalstackPlugin(serverless, {})
+
+      serverless.providers.aws.request('Lambda','foo',{});
+
+      expect(this.credentials.endpoint).to.equal('http://localstack:4574')
+      done()
+    });
+
+    it('should not set the endpoint if the required endpoint service is not defined', (done) => {
+      this.serverlessAwsProvider.sdk = {
+        Lambda: this.FakeService,
+        bobbins: this.FakeService,
+      };
+
+      instance = new LocalstackPlugin(serverless, {})
+
+      serverless.providers.aws.request('bobbins','foo',{}).then((result) => {
+        expect(result).to.be.true;
+      });
+
+      done()
+    });
+
+  });
 
 })


### PR DESCRIPTION
This PR is a proof-of-concept for utilizing AWS.config vs overriding and reimplementing the AWS request method.

I should note that the request method is still overridden but only for logging and bug fix purposes. In addition, this should also address #1 by preventing validateTemplate calls from being made to Localstack (it's not supported).