### PR TITLE
Added the ability to selectively apply the plugin depending on the deploy stage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ global override support while also override specific endpoints.
 
 A "host" or individual endpoints must be configured or this plugin will be deactivated.
 
-#### Configuring endpoints via serverless.yml 
+#### Configuring endpoints via serverless.yml
 
 ```
 service: myService
@@ -76,6 +76,24 @@ custom:
     endpointFile: path/to/file.json
 ```
 
+#### Only enable serverless-plugin-localstack for the listed stages
+* ```serverless deploy --stage local``` would deploy to localstack.
+* ```serverless deploy --stage production``` would deploy to aws.
+
+```
+service: myService
+
+plugins:
+  - serverless-plugin-localstack
+
+custom:
+  localstack:
+    stages:
+      - local
+      - dev
+    endpointFile: path/to/file.json
+```
+
 ## Localstack
 
 For full documentation, see https://bitbucket.org/atlassian/localstack
@@ -100,7 +118,7 @@ git clone git@bitbucket.org:atlassian/localstack.git
 There are multiple ways to run Localstack.
 
 #### Starting Localstack via Docker
-  
+
 If Localstack is installed via pip
 
 ```

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -86,6 +86,26 @@ describe("LocalstackPlugin", () => {
         expect(instance.endpoints).to.deep.equal(endpoints)
       });
 
+      it('should not set the endpoints if the stages config option does not include the deployment stage', () => {
+          serverless.service.custom.localstack.stages = ['production'];
+
+          let plugin = new LocalstackPlugin(serverless, {})
+
+          expect(plugin.endpoints).to.be.empty;
+      });
+
+      it('should set the endpoints if the stages config option includes the deployment stage', () => {
+        serverless.service.custom.localstack.stages = ['production', 'staging'];
+
+        let plugin = new LocalstackPlugin(serverless, {'stage':'production'})
+
+        let endpoints = JSON.parse(fs.readFileSync(localstackEndpointsFile))
+
+        expect(plugin.config.stages).to.deep.equal(['production','staging']);
+        expect(plugin.config.stage).to.equal('production');
+        expect(plugin.endpoints).to.deep.equal(endpoints)
+      });
+
       it('should fail if the endpoint file does not exist', () => {
         serverless.service.custom.localstack = {
           endpointFile: 'missing.json'

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ class LocalstackPlugin {
 
     //If the target stage is listed in config.stages use the serverless-localstack-plugin
     //To keep default behavior if config.stages is undefined, then use serverless-localstack-plugin
-    if(this.config.stages === undefined || this.config.stages.includes(this.config.stage)){
+    if(this.config.stages === undefined || this.config.stages.indexOf(this.config.stage) > -1){
       this.log('Using serverless-localstack-plugin');
       this.endpoints = this.config.endpoints || {};
       this.endpointFile = this.config.endpointFile;
@@ -36,7 +36,7 @@ class LocalstackPlugin {
         'sns': 4575,
         'sqs': 4576
       };
-      
+
       if (this.endpointFile) {
         this.loadEndpointsFromDisk(this.endpointFile);
       }


### PR DESCRIPTION
I wanted to be able to choose which stages were deployed to localstack and which stages were deployed to aws without having to comment or uncomment the plugin.

~~Is there a better way to get the deployment target from serverless? (line 13 of src/index.js)~~
Had to move things around and call the plugin code from a hook so that variable references are resolved.

Added tests for the changes.  
Added config example to the readme.