### PR TITLE
Fix the custom config read issue

### DIFF
--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -50,6 +50,7 @@ describe("LocalstackPlugin", () => {
   });
 
   let simulateBeforeDeployHooks = function(instance){
+    instance.readConfig();
     instance.getStageVariable()
     instance.reconfigureAWS()
   }
@@ -117,7 +118,7 @@ describe("LocalstackPlugin", () => {
           endpointFile: 'missing.json'
         }
 
-        let plugin = () => { new LocalstackPlugin(serverless, {}) }
+        let plugin = () => {let instnace = new LocalstackPlugin(serverless, {}); instance.readConfig() }
 
         expect(plugin).to.throw('Endpoint: "missing.json" is invalid:')
       });
@@ -126,7 +127,7 @@ describe("LocalstackPlugin", () => {
         serverless.service.custom.localstack = {
           endpointFile: 'README.md'
         }
-        let plugin = () => { new LocalstackPlugin(serverless, {}) }
+        let plugin = () => {let instnace = new LocalstackPlugin(serverless, {}); instance.readConfig() }
         expect(plugin).to.throw(/Endpoint: "README.md" is invalid:/)
       });
 

--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -118,7 +118,7 @@ describe("LocalstackPlugin", () => {
           endpointFile: 'missing.json'
         }
 
-        let plugin = () => {let instnace = new LocalstackPlugin(serverless, {}); instance.readConfig() }
+        let plugin = () => {let pluginInstance = new LocalstackPlugin(serverless, {}); pluginInstance.readConfig() }
 
         expect(plugin).to.throw('Endpoint: "missing.json" is invalid:')
       });
@@ -127,7 +127,7 @@ describe("LocalstackPlugin", () => {
         serverless.service.custom.localstack = {
           endpointFile: 'README.md'
         }
-        let plugin = () => {let instnace = new LocalstackPlugin(serverless, {}); instance.readConfig() }
+        let plugin = () => {let pluginInstance = new LocalstackPlugin(serverless, {}); pluginInstance.readConfig() }
         expect(plugin).to.throw(/Endpoint: "README.md" is invalid:/)
       });
 


### PR DESCRIPTION
Issue:
If the custom config value is a reference file like:
custom: ${file(./local.yml)}

The localstack values could not be resolved.

Fix:
Don't read the config in the constructor, do it before reconfigAWS, which serverless will resolve that file for us.