### PR TITLE
Fix example

### DIFF
--- a/example/service/serverless.yml
+++ b/example/service/serverless.yml
@@ -5,12 +5,12 @@ provider:
   runtime: nodejs6.10
 
 plugins:
-  - serverless-plugin-localstack
+  - serverless-localstack
 
 custom:
   localstack:
     host: http://localhost
-    endpoint: localstack_endpoints.json
+    endpointFile: localstack_endpoints.json
 
 functions:
   hello:


### PR DESCRIPTION
The example was not using the proper key for utilizing a .json endpoint definition. In addition, it was still using the old plugin name.

This also assists in closing #32