### PR TITLE
Revert "Template validation is now supported by LocalStack, closes #12"

### DIFF
--- a/spec/unit/index.spec.js
+++ b/spec/unit/index.spec.js
@@ -177,6 +177,15 @@ describe("LocalstackPlugin", () => {
       expect(templateUrl).to.startsWith(`${config.host}`);
     });
 
+    it('should not send validateTemplate calls to localstack', () => {
+      let pathToTemplate = 'https://s3.amazonaws.com/path/to/template';
+      let request = sinon.stub(awsProvider, 'request');
+      instance = new LocalstackPlugin(serverless, {})
+      awsProvider.request('S3','validateTemplate',{});
+
+      expect(request.called).to.be.false;
+    });
+
   });
 
 })

--- a/src/index.js
+++ b/src/index.js
@@ -132,6 +132,12 @@ class LocalstackPlugin {
   }
 
   interceptRequest(service, method, params) {
+    // // Template validation is not supported in LocalStack
+    if (method == "validateTemplate") {
+      this.log('Skipping template validation: Unsupported in Localstack');
+      return Promise.resolve("");
+    }
+
     if (AWS.config[service.toLowerCase()]) {
       this.debug(`Using custom endpoint for ${service}: ${AWS.config[service].endpoint}`);
 
@@ -142,6 +148,7 @@ class LocalstackPlugin {
     }
 
     return this.awsProviderRequest(service, method, params);
+
   }
 }
 


### PR DESCRIPTION
Based on feedback provided here: https://github.com/temyers/serverless-localstack/issues/22#issuecomment-421631823, this merge should be reverted.